### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/activate.yml
+++ b/tasks/activate.yml
@@ -29,7 +29,8 @@
                           --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           enabled <b>AWS Config</b> in

--- a/tasks/deactivate.yml
+++ b/tasks/deactivate.yml
@@ -34,7 +34,8 @@
                 --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           disabled <b>AWS Config</b> in

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
     _aws_config_url: 'https://console.aws.amazon.com/config/home'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-config</b>
@@ -25,7 +26,8 @@
   with_items: '{{ _aws_config_inactive_regions }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-config</b>


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.